### PR TITLE
[Pull Request] 六项修复及优化, 四项新增

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -146,7 +146,7 @@ namespace KitX_Dashboard
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("In AnouncementManager.CheckNewAccnouncements()", ex);
+                        Log.Error(ex, "In AnouncementManager.CheckNewAccnouncements()");
                     }
                 }).Start();
 

--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Threading;
 
 #pragma warning disable CS8604 // 引用类型参数可能为 null。
+#pragma warning disable CA2211 // Non-constant fields should not be visible
 
 namespace KitX_Dashboard
 {
@@ -158,6 +159,7 @@ namespace KitX_Dashboard
     }
 }
 
+#pragma warning restore CA2211 // Non-constant fields should not be visible
 #pragma warning restore CS8604 // 引用类型参数可能为 null。
 
 //                                         .....'',;;::cccllllllllllllcccc:::;;,,,''...'',,'..

--- a/Helper.cs
+++ b/Helper.cs
@@ -290,6 +290,8 @@ namespace KitX_Dashboard
         /// </summary>
         public static void Exit()
         {
+            Log.CloseAndFlush();
+
             Program.WebManager?.Stop();
             Program.WebManager?.Dispose();
 

--- a/Helper.cs
+++ b/Helper.cs
@@ -307,12 +307,12 @@ namespace KitX_Dashboard
         public static void InitEnvironment()
         {
             #region 检查 Common.Algorithm 库环境并安装环境
-            if (!Algorithm.Interop.Environment.CheckEnvironment())
+            if (!Common.Algorithm.Interop.Environment.CheckEnvironment())
                 new Thread(() =>
                 {
                     try
                     {
-                        Algorithm.Interop.Environment.InstallEnvironment();
+                        Common.Algorithm.Interop.Environment.InstallEnvironment();
                     }
                     catch (Exception ex)
                     {

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -140,7 +140,7 @@
         <PackageReference Include="nulastudio.NetBeauty" Version="2.0.0-beta.6" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
+        <PackageReference Include="XamlNameReferenceGenerator" Version="1.5.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\KitX Dashboard Helper\KitX.Assets\KitX.Assets.csproj" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -10,9 +10,9 @@
         <ApplicationIcon>Assets\KitX-Icon-256x.ico</ApplicationIcon>
         <BaseOutputPath>..\KitX Build\Dashboard\</BaseOutputPath>
         <BaseIntermediateOutputPath>..\KitX Build\Temp\Dashboard\</BaseIntermediateOutputPath>
-        <AssemblyVersion>3.22.04.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-07-16"))).TotalDays)</AssemblyVersion>
-        <FileVersion>3.22.04.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-07-16"))).TotalDays)</FileVersion>
-        <Version>3.22.04.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-07-16"))).TotalDays)</Version>
+        <AssemblyVersion>$(Version)</AssemblyVersion>
+        <FileVersion>$(Version)</FileVersion>
+        <Version>3.22.10.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-06-06"))).TotalDays)</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(IsBuild4WindowsPlatform) == 'True'">
@@ -155,5 +155,6 @@
         <ProjectReference Include="..\KitX Dashboard Helper\KitX.Fonts\KitX.Fonts.csproj" />
         <ProjectReference Include="..\KitX File Format Helper\KitX.KXP.Helper\KitX.KXP.Helper.csproj" />
         <ProjectReference Include="..\KitX Rules\KitX.Web.Rules\KitX.Web.Rules.csproj" />
+        <ProjectReference Include="..\Reference\Common.ExternalConsole\Common.ExternalConsole.Console\Common.ExternalConsole.Console.csproj" />
     </ItemGroup>
 </Project>

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -133,7 +133,7 @@
         <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
         <PackageReference Include="Common.BasicHelper" Version="1.2.6402.1373" />
         <PackageReference Include="Common.Activity" Version="1.0.6346.961" />
-        <PackageReference Include="Common.Algorithm.Interop" Version="1.2.6407.686" />
+        <PackageReference Include="Common.Algorithm.Interop" Version="1.2.6407.702" />
         <PackageReference Include="Common.ExternalConsole" Version="1.0.6407.192" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
         <!--<PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" Condition="$(IsBuild4WindowsPlatform) == 'True'" />-->

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -136,7 +136,7 @@
         <PackageReference Include="Common.Algorithm.Interop" Version="1.2.6402.1374" />
         <PackageReference Include="Common.ExternalConsole" Version="1.0.6402.1394" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
-        <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" Condition="$(IsBuild4WindowsPlatform) == 'True'" />
+        <!--<PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" Condition="$(IsBuild4WindowsPlatform) == 'True'" />-->
         <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />
         <PackageReference Include="KitX.KXP.Helper" Version="22.4.6351.975" />
         <PackageReference Include="KitX.Web.Rules" Version="22.4.6351.974" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
         <TargetFramework Condition="$(IsBuild4WindowsPlatform) == 'False'">net6.0</TargetFramework>
         <TargetFramework Condition="$(IsBuild4WindowsPlatform) == 'True'">net6.0-windows10.0.17763.0</TargetFramework>
         <Nullable>enable</Nullable>
@@ -64,7 +64,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="Assets\KitX-Icon-256x256.ico" />
+        <None Remove="Assets\KitX-Icon-256x256.ico" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="Languages\en-us.axaml">
@@ -128,14 +128,14 @@
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="0.10.18" />
         <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.18" Condition="'$(Configuration)' == 'Debug'" />
         <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.18" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
         <PackageReference Include="Common.BasicHelper" Version="1.1.6360.850" />
         <PackageReference Include="Common.Activity" Version="1.0.6346.961" />
         <PackageReference Include="Common.Algorithm.Interop" Version="1.1.6345.985" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
-        <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" />
+        <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" Condition="$(IsBuild4WindowsPlatform) == 'True'" />
         <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />
         <PackageReference Include="KitX.KXP.Helper" Version="22.4.6351.975" />
         <PackageReference Include="KitX.Web.Rules" Version="22.4.6351.974" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <TargetFramework Condition="$(IsBuild4WindowsPlatform) == 'False'">net6.0</TargetFramework>
+        <TargetFramework Condition="$(IsBuild4WindowsPlatform) == 'True'">net6.0-windows10.0.17763.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TrimMode>copyused</TrimMode>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
@@ -11,6 +13,10 @@
         <AssemblyVersion>3.22.04.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-07-16"))).TotalDays)</AssemblyVersion>
         <FileVersion>3.22.04.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-07-16"))).TotalDays)</FileVersion>
         <Version>3.22.04.$([System.DateTime]::UtcNow.Date.Subtract($([System.DateTime]::Parse("2005-07-16"))).TotalDays)</Version>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(IsBuild4WindowsPlatform) == 'True'">
+        <DefineConstants>IsBuild4WindowsPlatform</DefineConstants>
     </PropertyGroup>
 
     <!--<ItemGroup>
@@ -129,6 +135,7 @@
         <PackageReference Include="Common.Activity" Version="1.0.6346.961" />
         <PackageReference Include="Common.Algorithm.Interop" Version="1.1.6345.985" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
+        <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" />
         <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />
         <PackageReference Include="KitX.KXP.Helper" Version="22.4.6351.975" />
         <PackageReference Include="KitX.Web.Rules" Version="22.4.6351.974" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -130,8 +130,8 @@
         <PackageReference Include="Common.Algorithm.Interop" Version="1.1.6345.985" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
         <PackageReference Include="FluentAvaloniaUI" Version="1.4.4" />
-        <PackageReference Include="KitX.KXP.Helper" Version="22.4.6276.567" />
-        <PackageReference Include="KitX.Web.Rules" Version="22.4.6276.567" />
+        <PackageReference Include="KitX.KXP.Helper" Version="22.4.6351.975" />
+        <PackageReference Include="KitX.Web.Rules" Version="22.4.6351.974" />
         <PackageReference Include="LiteDB" Version="5.0.12" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.400" />
         <PackageReference Include="Markdown.Avalonia" Version="0.10.11" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -133,8 +133,8 @@
         <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
         <PackageReference Include="Common.BasicHelper" Version="1.2.6402.1373" />
         <PackageReference Include="Common.Activity" Version="1.0.6346.961" />
-        <PackageReference Include="Common.Algorithm.Interop" Version="1.2.6402.1374" />
-        <PackageReference Include="Common.ExternalConsole" Version="1.0.6402.1394" />
+        <PackageReference Include="Common.Algorithm.Interop" Version="1.2.6407.686" />
+        <PackageReference Include="Common.ExternalConsole" Version="1.0.6407.192" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
         <!--<PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" Condition="$(IsBuild4WindowsPlatform) == 'True'" />-->
         <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -125,16 +125,16 @@
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
         <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.18" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-        <PackageReference Include="Common.BasicHelper" Version="1.1.6347.236" />
+        <PackageReference Include="Common.BasicHelper" Version="1.1.6360.850" />
         <PackageReference Include="Common.Activity" Version="1.0.6346.961" />
         <PackageReference Include="Common.Algorithm.Interop" Version="1.1.6345.985" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
-        <PackageReference Include="FluentAvaloniaUI" Version="1.4.4" />
+        <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />
         <PackageReference Include="KitX.KXP.Helper" Version="22.4.6351.975" />
         <PackageReference Include="KitX.Web.Rules" Version="22.4.6351.974" />
-        <PackageReference Include="LiteDB" Version="5.0.12" />
+        <PackageReference Include="LiteDB" Version="5.0.13" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.400" />
-        <PackageReference Include="Markdown.Avalonia" Version="0.10.11" />
+        <PackageReference Include="Markdown.Avalonia" Version="0.10.12" />
         <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />
         <PackageReference Include="MessageBox.Avalonia" Version="2.1.0" />
         <PackageReference Include="nulastudio.NetBeauty" Version="2.0.0-beta.6" />

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -131,15 +131,16 @@
         <PackageReference Include="Avalonia.Diagnostics" Version="0.10.18" Condition="'$(Configuration)' == 'Debug'" />
         <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.18" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-        <PackageReference Include="Common.BasicHelper" Version="1.1.6360.850" />
+        <PackageReference Include="Common.BasicHelper" Version="1.2.6402.1373" />
         <PackageReference Include="Common.Activity" Version="1.0.6346.961" />
-        <PackageReference Include="Common.Algorithm.Interop" Version="1.1.6345.985" />
+        <PackageReference Include="Common.Algorithm.Interop" Version="1.2.6402.1374" />
+        <PackageReference Include="Common.ExternalConsole" Version="1.0.6402.1394" />
         <PackageReference Include="Common.Update.Checker" Version="1.0.1.3" />
         <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" Condition="$(IsBuild4WindowsPlatform) == 'True'" />
         <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />
         <PackageReference Include="KitX.KXP.Helper" Version="22.4.6351.975" />
         <PackageReference Include="KitX.Web.Rules" Version="22.4.6351.974" />
-        <PackageReference Include="LiteDB" Version="5.0.13" />
+        <PackageReference Include="LiteDB" Version="5.0.14" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.400" />
         <PackageReference Include="Markdown.Avalonia" Version="0.10.12" />
         <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />

--- a/Languages/en-us.axaml
+++ b/Languages/en-us.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">Exit</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">Show Main Window</x:String>
     <x:String x:Key="Text_Public_Second">s</x:String>
+    <x:String x:Key="Text_Public_Minute">minute</x:String>
+    <x:String x:Key="Text_Public_Hour">hour</x:String>
     <x:String x:Key="Text_Public_Tip">Tip</x:String>
     <x:String x:Key="Text_Public_Delete">Delete</x:String>
     <x:String x:Key="Text_Public_Replace">Replace</x:String>

--- a/Languages/en-us.axaml
+++ b/Languages/en-us.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">Developer Settings</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">Show Announcements When Start</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">Show Announcements Now</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">Open Debug Tool</x:String>
     <x:String x:Key="Text_Settings_Personalise">Personalise</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">Display Language</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">Mica Effect</x:String>

--- a/Languages/en-us.axaml
+++ b/Languages/en-us.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">Task</x:String>
     <x:String x:Key="Text_Public_Size">Size</x:String>
     <x:String x:Key="Text_Public_Developing">Developing ...</x:String>
+    <x:String x:Key="Text_Public_Empty">Empty</x:String>
+    <x:String x:Key="Text_Public_Refresh">Refresh</x:String>
     <x:String x:Key="Text_Log_Verbose">Verbose</x:String>
     <x:String x:Key="Text_Log_Debug">Debug</x:String>
     <x:String x:Key="Text_Log_Information">Infomation</x:String>
@@ -111,6 +113,7 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">Native IP Filter</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">Greeting Text Update Interval</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">Log File Relative Settings</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">The log file has taken up space</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">Log File Max Size</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">Log File Max Count</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">Log File Flush Interval</x:String>

--- a/Languages/fr-fr.axaml
+++ b/Languages/fr-fr.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">option de développeur</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">Afficher l'annonce au démarrage</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">Voir les dernières annonces</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">Ouvrir le débogueur</x:String>
     <x:String x:Key="Text_Settings_Personalise">personnaliser</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">langue d'affichage</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">Effet mica</x:String>

--- a/Languages/fr-fr.axaml
+++ b/Languages/fr-fr.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">Tâche</x:String>
     <x:String x:Key="Text_Public_Size">Taille</x:String>
     <x:String x:Key="Text_Public_Developing">En développement</x:String>
+    <x:String x:Key="Text_Public_Empty">vide</x:String>
+    <x:String x:Key="Text_Public_Refresh">rafraîchir</x:String>
     <x:String x:Key="Text_Log_Verbose">détaillé</x:String>
     <x:String x:Key="Text_Log_Debug">débogage</x:String>
     <x:String x:Key="Text_Log_Information">informations</x:String>
@@ -111,6 +113,7 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">Règles de filtrage IP natives</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">Mise à jour du message d'accueil retardée</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">Paramètres liés au fichier journal</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">Le fichier journal a pris de la place</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">Limite de taille du fichier journal</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">limite du fichier journal</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">Délai du cache du fichier journal</x:String>

--- a/Languages/fr-fr.axaml
+++ b/Languages/fr-fr.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">quitter</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">Afficher la fenêtre principale</x:String>
     <x:String x:Key="Text_Public_Second">deuxième</x:String>
+    <x:String x:Key="Text_Public_Minute">minute</x:String>
+    <x:String x:Key="Text_Public_Hour">Heure</x:String>
     <x:String x:Key="Text_Public_Tip">indice</x:String>
     <x:String x:Key="Text_Public_Delete">effacer</x:String>
     <x:String x:Key="Text_Public_Replace">remplacer</x:String>

--- a/Languages/ja-jp.axaml
+++ b/Languages/ja-jp.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">仕事</x:String>
     <x:String x:Key="Text_Public_Size">サイズ</x:String>
     <x:String x:Key="Text_Public_Developing">開発中</x:String>
+    <x:String x:Key="Text_Public_Empty">空の</x:String>
+    <x:String x:Key="Text_Public_Refresh">リフレッシュする</x:String>
     <x:String x:Key="Text_Log_Verbose">详细</x:String>
     <x:String x:Key="Text_Log_Debug">调试</x:String>
     <x:String x:Key="Text_Log_Information">情報</x:String>
@@ -111,6 +113,7 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">ネイティブ IP フィルタリング ルール</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">あいさつ更新が遅れる</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">ログファイル関連の設定</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">ログファイルがスペースを占有しています</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">ログ ファイルのサイズ制限</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">ログ ファイルの制限</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">ログ ファイル キャッシュの遅延</x:String>

--- a/Languages/ja-jp.axaml
+++ b/Languages/ja-jp.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">終了する</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">メインウィンドウを表示</x:String>
     <x:String x:Key="Text_Public_Second">2番目</x:String>
+    <x:String x:Key="Text_Public_Minute">分</x:String>
+    <x:String x:Key="Text_Public_Hour">時間</x:String>
     <x:String x:Key="Text_Public_Tip">ヒント</x:String>
     <x:String x:Key="Text_Public_Delete">消去</x:String>
     <x:String x:Key="Text_Public_Replace">交換</x:String>

--- a/Languages/ja-jp.axaml
+++ b/Languages/ja-jp.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">開発者向けオプション</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">起動時にアナウンスを表示</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">最新のお知らせを見る</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">デバッガーを開く</x:String>
     <x:String x:Key="Text_Settings_Personalise">パーソナライズ</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">表示言語</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">Mica 効果</x:String>

--- a/Languages/ko-kr.axaml
+++ b/Languages/ko-kr.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">개발자 옵션</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">시작 시 알림 표시</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">최신 공지사항 보기</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">디버거 열기</x:String>
     <x:String x:Key="Text_Settings_Personalise">개인화</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">표시 언어</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">운모 효과</x:String>

--- a/Languages/ko-kr.axaml
+++ b/Languages/ko-kr.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">일</x:String>
     <x:String x:Key="Text_Public_Size">크기</x:String>
     <x:String x:Key="Text_Public_Developing">개발 중</x:String>
+    <x:String x:Key="Text_Public_Empty">비어 있는</x:String>
+    <x:String x:Key="Text_Public_Refresh">새로 고침</x:String>
     <x:String x:Key="Text_Log_Verbose">상세한</x:String>
     <x:String x:Key="Text_Log_Debug">디버깅</x:String>
     <x:String x:Key="Text_Log_Information">정보</x:String>
@@ -111,6 +113,7 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">기본 IP 필터링 규칙</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">인사말 업데이트가 지연되었습니다.</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">로그 파일 관련 설정</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">로그 파일이 공간을 차지했습니다.</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">로그 파일 크기 제한</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">로그 파일 제한</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">로그 파일 캐시 지연</x:String>

--- a/Languages/ko-kr.axaml
+++ b/Languages/ko-kr.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">그만두다</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">메인 창 표시</x:String>
     <x:String x:Key="Text_Public_Second">초</x:String>
+    <x:String x:Key="Text_Public_Minute">분</x:String>
+    <x:String x:Key="Text_Public_Hour">시</x:String>
     <x:String x:Key="Text_Public_Tip">힌트</x:String>
     <x:String x:Key="Text_Public_Delete">삭제</x:String>
     <x:String x:Key="Text_Public_Replace">바꾸다</x:String>

--- a/Languages/ru-ru.axaml
+++ b/Languages/ru-ru.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">покидать</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">Показать главное окно</x:String>
     <x:String x:Key="Text_Public_Second">второй</x:String>
+    <x:String x:Key="Text_Public_Minute">минута</x:String>
+    <x:String x:Key="Text_Public_Hour">Час</x:String>
     <x:String x:Key="Text_Public_Tip">намекать</x:String>
     <x:String x:Key="Text_Public_Delete">Удалить</x:String>
     <x:String x:Key="Text_Public_Replace">заменять</x:String>

--- a/Languages/ru-ru.axaml
+++ b/Languages/ru-ru.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">вариант разработчика</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">Показывать объявление при запуске</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">Посмотреть последние объявления</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">Откройте отладчик</x:String>
     <x:String x:Key="Text_Settings_Personalise">персонализировать</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">язык отображения</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">Эффект слюды</x:String>

--- a/Languages/ru-ru.axaml
+++ b/Languages/ru-ru.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">Задача</x:String>
     <x:String x:Key="Text_Public_Size">размер</x:String>
     <x:String x:Key="Text_Public_Developing">В развитие</x:String>
+    <x:String x:Key="Text_Public_Empty">пустой</x:String>
+    <x:String x:Key="Text_Public_Refresh">обновить</x:String>
     <x:String x:Key="Text_Log_Verbose">подробный</x:String>
     <x:String x:Key="Text_Log_Debug">отладка</x:String>
     <x:String x:Key="Text_Log_Information">Информация</x:String>
@@ -111,6 +113,7 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">Собственные правила IP-фильтрации</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">Обновление приветствия отложено</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">Настройки, связанные с файлом журнала</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">Файл журнала занял место</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">Ограничение размера файла журнала</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">лимит файла журнала</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">Задержка кеша файла журнала</x:String>

--- a/Languages/zh-cn.axaml
+++ b/Languages/zh-cn.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">退出</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">显示主窗口</x:String>
     <x:String x:Key="Text_Public_Second">秒</x:String>
+    <x:String x:Key="Text_Public_Minute">分钟</x:String>
+    <x:String x:Key="Text_Public_Hour">小时</x:String>
     <x:String x:Key="Text_Public_Tip">提示</x:String>
     <x:String x:Key="Text_Public_Delete">删除</x:String>
     <x:String x:Key="Text_Public_Replace">替换</x:String>

--- a/Languages/zh-cn.axaml
+++ b/Languages/zh-cn.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">任务</x:String>
     <x:String x:Key="Text_Public_Size">大小</x:String>
     <x:String x:Key="Text_Public_Developing">该部分正在开发中</x:String>
+    <x:String x:Key="Text_Public_Empty">清空</x:String>
+    <x:String x:Key="Text_Public_Refresh">刷新</x:String>
     <x:String x:Key="Text_Log_Verbose">详细</x:String>
     <x:String x:Key="Text_Log_Debug">调试</x:String>
     <x:String x:Key="Text_Log_Information">信息</x:String>
@@ -111,6 +113,7 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">本机IP过滤规则</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">招呼语更新延迟</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">日志文件相关设置</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">日志文件已占用空间</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">日志文件体积限制</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">日志文件数量限制</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">日志文件缓存延时</x:String>

--- a/Languages/zh-cn.axaml
+++ b/Languages/zh-cn.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">开发者选项</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">启动时显示公告</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">查看最新公告</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">打开调试工具</x:String>
     <x:String x:Key="Text_Settings_Personalise">个性化</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">显示语言</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">云母效果</x:String>

--- a/Languages/zh-tw.axaml
+++ b/Languages/zh-tw.axaml
@@ -97,6 +97,7 @@
     <x:String x:Key="Text_Settings_General_DeveloperSetting">開發者設定</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncement">啓動時顯示公告</x:String>
     <x:String x:Key="Text_Settings_General_ShowAnnouncementNow">查看新公告</x:String>
+    <x:String x:Key="Text_Settings_General_OpenDebugTool">打開調試工具</x:String>
     <x:String x:Key="Text_Settings_Personalise">個性化</x:String>
     <x:String x:Key="Text_Settings_Personalise_DisplayLanguage">顯示語言</x:String>
     <x:String x:Key="Text_Settings_Personalise_MicaEffect">雲母效果</x:String>

--- a/Languages/zh-tw.axaml
+++ b/Languages/zh-tw.axaml
@@ -21,6 +21,8 @@
     <x:String x:Key="Text_Public_Task">任務</x:String>
     <x:String x:Key="Text_Public_Size">大小</x:String>
     <x:String x:Key="Text_Public_Developing">該部分正在開發中</x:String>
+    <x:String x:Key="Text_Public_Empty">清空</x:String>
+    <x:String x:Key="Text_Public_Refresh">刷新</x:String>
     <x:String x:Key="Text_Log_Verbose">詳細</x:String>
     <x:String x:Key="Text_Log_Debug">調試</x:String>
     <x:String x:Key="Text_Log_Information">信息</x:String>
@@ -111,11 +113,12 @@
     <x:String x:Key="Text_Settings_Performence_Web_MyIP_Filter">本機IP過濾器</x:String>
     <x:String x:Key="Text_Settings_Performence_Greeting_Interval">招呼語更新延遲</x:String>
     <x:String x:Key="Text_Settings_Performence_Log">日志文檔相關設定</x:String>
+    <x:String x:Key="Text_Settings_Performence_LogFileSizeUsage">日誌文件已佔用空間</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileSize">日志文檔大小限制</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileMaxCount">日志文檔數量限制</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileFlushInterval">日志文檔緩衝延時</x:String>
     <x:String x:Key="Text_Settings_Performence_LogFileLevel">日志級別</x:String>
-    <x:String x:Key="Text_Settings_Performence_CheckerThreadCountLimit">更新檢查每綫程處理文件數量</x:String>
+    <x:String x:Key="Text_Settings_Performence_CheckerPerThreadFilesCountLimit">更新檢查每綫程處理文件數量</x:String>
     <x:String x:Key="Text_Settings_Update">更新</x:String>
     <x:String x:Key="Text_Settings_Update_Check">檢查更新</x:String>
     <x:String x:Key="Text_Settings_Update_ComponentName">組件名稱</x:String>

--- a/Languages/zh-tw.axaml
+++ b/Languages/zh-tw.axaml
@@ -13,6 +13,8 @@
     <x:String x:Key="Text_Public_Exit">退出</x:String>
     <x:String x:Key="Text_Public_ShowMainWindow">顯示主窗口</x:String>
     <x:String x:Key="Text_Public_Second">秒</x:String>
+    <x:String x:Key="Text_Public_Minute">分鐘</x:String>
+    <x:String x:Key="Text_Public_Hour">小時</x:String>
     <x:String x:Key="Text_Public_Tip">提示</x:String>
     <x:String x:Key="Text_Public_Delete">刪除</x:String>
     <x:String x:Key="Text_Public_Replace">替換</x:String>

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.ReactiveUI;
+#if (IsBuild4WindowsPlatform == true)
 using DesktopNotifications.Avalonia;
+#endif
 using KitX_Dashboard.Data;
 using KitX_Dashboard.Services;
 using KitX_Dashboard.Views;

--- a/Program.cs
+++ b/Program.cs
@@ -16,8 +16,6 @@ namespace KitX_Dashboard
 {
     internal class Program
     {
-        //internal static LoggerManager LocalLogger = new();
-
         internal static AppConfig Config = new();
 
         internal static WebManager? WebManager;

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.ReactiveUI;
+using DesktopNotifications.Avalonia;
 using KitX_Dashboard.Data;
 using KitX_Dashboard.Services;
 using KitX_Dashboard.Views;
@@ -147,10 +148,13 @@ namespace KitX_Dashboard
         /// Avalonia 配置项, 请不要删除; 同时也用于可视化设计器
         public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
             .UsePlatformDetect().LogToTrace().UseReactiveUI()
+#if (IsBuild4WindowsPlatform == true)
+            .SetupDesktopNotifications()
+#endif
             .With(new Win32PlatformOptions
             {
                 UseWindowsUIComposition = true,
-                EnableMultitouch = true
+                EnableMultitouch = true,
             })
             .With(new MacOSPlatformOptions
             {

--- a/Properties/PublishProfiles/linux-arm-single-cut.pubxml
+++ b/Properties/PublishProfiles/linux-arm-single-cut.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-linux-arm-single-cut\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-linux-arm-single-cut\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>true</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/linux-arm-single.pubxml
+++ b/Properties/PublishProfiles/linux-arm-single.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-linux-arm-single\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-linux-arm-single\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>false</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/linux-arm64-single-cut.pubxml
+++ b/Properties/PublishProfiles/linux-arm64-single-cut.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-linux-arm64-single-cut\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-linux-arm64-single-cut\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>true</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/linux-arm64-single.pubxml
+++ b/Properties/PublishProfiles/linux-arm64-single.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-linux-arm64-single\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-linux-arm64-single\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>false</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/linux-x64-single-cut.pubxml
+++ b/Properties/PublishProfiles/linux-x64-single-cut.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-linux-x64-single-cut\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-linux-x64-single-cut\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>true</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/linux-x64-single.pubxml
+++ b/Properties/PublishProfiles/linux-x64-single.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-linux-x64-single\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-linux-x64-single\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>false</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/osx-x64-single-cut.pubxml
+++ b/Properties/PublishProfiles/osx-x64-single-cut.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-osx-x64-single-cut\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-osx-x64-single-cut\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>true</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/osx-x64-single.pubxml
+++ b/Properties/PublishProfiles/osx-x64-single.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-osx-x64-single\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-osx-x64-single\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishTrimmed>false</PublishTrimmed>
+        <IsBuild4WindowsPlatform>False</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x64-single-cut.pubxml
+++ b/Properties/PublishProfiles/win-x64-single-cut.pubxml
@@ -3,16 +3,17 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-win-x64-single-cut\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishTrimmed>true</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-win-x64-single-cut\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <PublishTrimmed>true</PublishTrimmed>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x64-single-cut.pubxml
+++ b/Properties/PublishProfiles/win-x64-single-cut.pubxml
@@ -14,6 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <PublishSingleFile>false</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
         <PublishTrimmed>true</PublishTrimmed>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <!--<IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>-->
     </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x64-single.pubxml
+++ b/Properties/PublishProfiles/win-x64-single.pubxml
@@ -14,6 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <PublishSingleFile>false</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
         <PublishTrimmed>false</PublishTrimmed>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <!--<IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>-->
     </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x64-single.pubxml
+++ b/Properties/PublishProfiles/win-x64-single.pubxml
@@ -3,16 +3,17 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-win-x64-single\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-win-x64-single\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <PublishTrimmed>false</PublishTrimmed>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x64.pubxml
+++ b/Properties/PublishProfiles/win-x64.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-win-x64\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>false</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-win-x64\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <SelfContained>false</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x64.pubxml
+++ b/Properties/PublishProfiles/win-x64.pubxml
@@ -13,6 +13,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <SelfContained>false</SelfContained>
         <PublishSingleFile>false</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <!--<IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>-->
+        <DisableBeauty>True</DisableBeauty>
     </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x86-single-cut.pubxml
+++ b/Properties/PublishProfiles/win-x86-single-cut.pubxml
@@ -3,16 +3,17 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-win-x86-single-cut\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishTrimmed>true</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-win-x86-single-cut\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <PublishTrimmed>true</PublishTrimmed>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x86-single-cut.pubxml
+++ b/Properties/PublishProfiles/win-x86-single-cut.pubxml
@@ -14,6 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <PublishSingleFile>false</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
         <PublishTrimmed>true</PublishTrimmed>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <!--<IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>-->
     </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x86-single.pubxml
+++ b/Properties/PublishProfiles/win-x86-single.pubxml
@@ -14,6 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <PublishSingleFile>false</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
         <PublishTrimmed>false</PublishTrimmed>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <!--<IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>-->
     </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x86-single.pubxml
+++ b/Properties/PublishProfiles/win-x86-single.pubxml
@@ -3,16 +3,17 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-win-x86-single\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-win-x86-single\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <SelfContained>true</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <PublishTrimmed>false</PublishTrimmed>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x86.pubxml
+++ b/Properties/PublishProfiles/win-x86.pubxml
@@ -3,15 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\KitX Publish\kitx-win-x86\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
-    <SelfContained>false</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishDir>..\KitX Publish\kitx-win-x86\</PublishDir>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <TargetFramework>net6.0</TargetFramework>
+        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <SelfContained>false</SelfContained>
+        <PublishSingleFile>false</PublishSingleFile>
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+    </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/win-x86.pubxml
+++ b/Properties/PublishProfiles/win-x86.pubxml
@@ -13,6 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
         <SelfContained>false</SelfContained>
         <PublishSingleFile>false</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
-        <IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>
+        <!--<IsBuild4WindowsPlatform>True</IsBuild4WindowsPlatform>-->
     </PropertyGroup>
 </Project>

--- a/Services/DebugService.cs
+++ b/Services/DebugService.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace KitX_Dashboard.Services
+{
+    internal class DebugService
+    {
+        /// <summary>
+        /// 执行命令
+        /// </summary>
+        /// <param name="cmd">命令</param>
+        /// <returns>执行结果</returns>
+        internal static string? ExecuteCommand(string cmd)
+        {
+            var header = cmd.GetCommandHeader();
+            if (header is null) return null;
+            var args = cmd.Trim()[header.Length..].GetCommandArgs();
+
+            return header switch
+            {
+                "version" => Assembly.GetEntryAssembly()?.GetName()?.Version?.ToString(),
+                _ => null,
+            };
+        }
+    }
+
+    internal static class DebugServiceTool
+    {
+        /// <summary>
+        /// 获取命令头
+        /// </summary>
+        /// <param name="cmd">命令</param>
+        /// <returns>命令头</returns>
+        internal static string? GetCommandHeader(this string cmd)
+        {
+            var command = cmd.Trim();
+            if (command is null) return null;
+            var header = command.Split(' ')[0];
+            return header;
+        }
+
+        /// <summary>
+        /// 获取命令参数
+        /// </summary>
+        /// <param name="cmd">命令</param>
+        /// <returns>参数字典</returns>
+        internal static Dictionary<string, string>? GetCommandArgs(this string cmd)
+        {
+            var args = new Dictionary<string, string>();
+            var command = cmd.Trim();
+            var pairs = command?.Split(' ');
+            if (pairs is null) return null;
+            if (pairs.Length % 2 != 0) return null;
+            for (var i = 0; i < pairs.Length; i += 2)
+            {
+                if (!pairs[i].Trim().StartsWith("--")) return null;
+                args.Add(pairs[i].Trim(), pairs[i + 1].Trim());
+            }
+            return args;
+        }
+
+        /// <summary>
+        /// 获取字典中的值
+        /// </summary>
+        /// <param name="src">字典</param>
+        /// <param name="key">键</param>
+        /// <returns>值</returns>
+        internal static string? Value(this Dictionary<string, string> src, string key)
+            => src.ContainsKey(key) ? src[key] : null;
+    }
+}

--- a/Services/DevicesManager.cs
+++ b/Services/DevicesManager.cs
@@ -208,7 +208,7 @@ namespace KitX_Dashboard.Services
                 {
                     receivedDeviceInfoStruct4Watch?.Clear();
                     receivedDeviceInfoStruct4Watch = null;
-                    Log.Error("In Watch4MainDevice", ex);
+                    Log.Error(ex, "In Watch4MainDevice");
                 }
             }).Start();
         }

--- a/Services/PluginsManager.cs
+++ b/Services/PluginsManager.cs
@@ -57,6 +57,8 @@ namespace KitX_Dashboard.Services
 
         internal static readonly Queue<Plugin> pluginsToDelete = new();
 
+        internal static readonly object PluginsListOperationLock = new();
+
         /// <summary>
         /// 持续检查并移除
         /// </summary>
@@ -236,14 +238,17 @@ namespace KitX_Dashboard.Services
                         while (pluginsToRemoveFromDB.Count > 0)
                         {
                             Plugin pg = pluginsToRemoveFromDB.Dequeue();
-                            Program.PluginsList.Plugins.RemoveAt(
-                                Program.PluginsList.Plugins.FindIndex(
-                                    x =>
-                                    {
-                                        if (x.InstallPath != null)
-                                            return x.InstallPath.Equals(pg.InstallPath);
-                                        else return false;
-                                    }));
+                            lock (PluginsListOperationLock)
+                            {
+                                Program.PluginsList.Plugins.RemoveAt(
+                                    Program.PluginsList.Plugins.FindIndex(
+                                        x =>
+                                        {
+                                            if (x.InstallPath != null)
+                                                return x.InstallPath.Equals(pg.InstallPath);
+                                            else return false;
+                                        }));
+                            }
                         }
                     }
 
@@ -253,14 +258,17 @@ namespace KitX_Dashboard.Services
                         while (pluginsToDelete.Count > 0)
                         {
                             Plugin pg = pluginsToDelete.Dequeue();
-                            Program.PluginsList.Plugins.RemoveAt(
-                                Program.PluginsList.Plugins.FindIndex(
-                                    x =>
-                                    {
-                                        if (x.InstallPath != null)
-                                            return x.InstallPath.Equals(pg.InstallPath);
-                                        else return false;
-                                    }));
+                            lock (PluginsListOperationLock)
+                            {
+                                Program.PluginsList.Plugins.RemoveAt(
+                                    Program.PluginsList.Plugins.FindIndex(
+                                        x =>
+                                        {
+                                            if (x.InstallPath != null)
+                                                return x.InstallPath.Equals(pg.InstallPath);
+                                            else return false;
+                                        }));
+                            }
                             string pgfiledir = Path.GetFullPath(
                                 $"{Program.Config.App.LocalPluginsFileDirectory}/" +
                                 $"{pg.PluginDetails.PublisherName}_{pg.PluginDetails.AuthorName}/" +

--- a/Services/PluginsManager.cs
+++ b/Services/PluginsManager.cs
@@ -152,18 +152,12 @@ namespace KitX_Dashboard.Services
                 if (workbase == null)
                     throw new Exception("Can not get path of \"KitX\"");
             }
-            string releaseDir = Path.GetFullPath($"{workbase}/{GlobalInfo.KXPTempReleasePath}");
             foreach (var item in kxpfiles)
             {
                 try
                 {
-                    if (Directory.Exists(releaseDir))
-                        Directory.Delete(releaseDir, true);
-                    _ = Directory.CreateDirectory(releaseDir);
-
                     KitX.KXP.Helper.Decoder decoder = new(item);
-                    Tuple<string, string> rst = decoder.Decode(releaseDir);
-                    Directory.Delete(releaseDir, true);
+                    Tuple<string, string> rst = decoder.GetLoaderAndPluginStruct();
                     LoaderStruct loaderStruct = JsonSerializer.Deserialize<LoaderStruct>(rst.Item1);
                     PluginStruct pluginStruct = JsonSerializer.Deserialize<PluginStruct>(rst.Item2);
                     AppConfig? config = null;

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1,15 +1,21 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using DesktopNotifications;
 using KitX_Dashboard.Commands;
 using KitX_Dashboard.Data;
 using KitX_Dashboard.Services;
 using KitX_Dashboard.Views;
+using Serilog;
 using System;
+using System.IO;
 using System.Threading;
 
 namespace KitX_Dashboard.ViewModels
 {
     internal class MainWindowViewModel : ViewModelBase
     {
+        private static bool _firstTime2RefreshGreeting = true;
+
         public MainWindowViewModel()
         {
             InitCommands();
@@ -19,11 +25,14 @@ namespace KitX_Dashboard.ViewModels
         {
             TrayIconClickedCommand = new(TrayIconClicked);
             ExitCommand = new(Exit);
+            RefreshGreetingCommand = new(RefreshGreeting);
         }
 
         internal DelegateCommand? TrayIconClickedCommand { get; set; }
 
         internal DelegateCommand? ExitCommand { get; set; }
+
+        internal DelegateCommand? RefreshGreetingCommand { get; set; }
 
         internal void TrayIconClicked(object mainWindow)
         {
@@ -46,6 +55,31 @@ namespace KitX_Dashboard.ViewModels
                 Thread.Sleep(GlobalInfo.LastBreakAfterExit);
                 Environment.Exit(0);
             }).Start();
+        }
+
+        internal void RefreshGreeting(object mainWindow)
+        {
+            MainWindow? win = mainWindow as MainWindow;
+            win?.UpdateGreetingText();
+            if (_firstTime2RefreshGreeting)
+            {
+                _firstTime2RefreshGreeting = false;
+                try
+                {
+                    var notificationManager =
+                        AvaloniaLocator.Current.GetService<INotificationManager>()
+                        ?? throw new InvalidDataException("Missing notification manager.");
+                    notificationManager.ShowNotification(new()
+                    {
+                        Title = GlobalInfo.AppName,
+                        Body = "(ノω<。)ノ))☆.。",
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, ex.Message);
+                }
+            }
         }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1,20 +1,25 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
+#if (IsBuild4WindowsPlatform == true)
+using Avalonia;
 using DesktopNotifications;
+using System.IO;
+#endif
 using KitX_Dashboard.Commands;
 using KitX_Dashboard.Data;
 using KitX_Dashboard.Services;
 using KitX_Dashboard.Views;
 using Serilog;
 using System;
-using System.IO;
 using System.Threading;
 
 namespace KitX_Dashboard.ViewModels
 {
     internal class MainWindowViewModel : ViewModelBase
     {
+
+#if (IsBuild4WindowsPlatform == true)
         private static bool _firstTime2RefreshGreeting = true;
+#endif
 
         public MainWindowViewModel()
         {
@@ -52,8 +57,15 @@ namespace KitX_Dashboard.ViewModels
 
             new Thread(() =>
             {
-                Thread.Sleep(GlobalInfo.LastBreakAfterExit);
-                Environment.Exit(0);
+                try
+                {
+                    Thread.Sleep(GlobalInfo.LastBreakAfterExit);
+                    Environment.Exit(0);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, $"In MainWindow.Exit(): {ex.Message}");
+                }
             }).Start();
         }
 
@@ -61,6 +73,7 @@ namespace KitX_Dashboard.ViewModels
         {
             MainWindow? win = mainWindow as MainWindow;
             win?.UpdateGreetingText();
+#if (IsBuild4WindowsPlatform == true)
             if (_firstTime2RefreshGreeting)
             {
                 _firstTime2RefreshGreeting = false;
@@ -80,6 +93,7 @@ namespace KitX_Dashboard.ViewModels
                     Log.Warning(ex, ex.Message);
                 }
             }
+#endif
         }
     }
 }

--- a/ViewModels/Pages/Controls/DevelopingViewModel.cs
+++ b/ViewModels/Pages/Controls/DevelopingViewModel.cs
@@ -4,12 +4,7 @@
     {
         public DevelopingViewModel()
         {
-            InitCommands();
-        }
-
-        private void InitCommands()
-        {
-
+            
         }
     }
 }

--- a/ViewModels/Pages/Controls/PluginBarViewModel.cs
+++ b/ViewModels/Pages/Controls/PluginBarViewModel.cs
@@ -146,24 +146,28 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
                 try
                 {
                     string? loaderName = PluginDetail?.RequiredLoaderStruct.LoaderName;
-                    string loaderFile = $"{Program.Config.Loaders.InstallPath}/{loaderName}/{loaderName}";
-                    if (OperatingSystem.IsWindows())
-                        loaderFile += ".exe";
-                    loaderFile = Path.GetFullPath(loaderFile);
-
                     var pd = PluginDetail?.PluginDetails;
                     string pluginPath = $"{PluginDetail?.InstallPath}/{pd?.RootStartupFileName}";
                     string pluginFile = Path.GetFullPath(pluginPath);
-
-                    Log.Information($"Launch: {pluginFile} through {loaderFile}");
-
-                    if (File.Exists(loaderFile) && File.Exists(pluginFile))
+                    string connectStr = $"{DevicesServer.DefaultDeviceInfoStruct.IPv4}" +
+                        $":{GlobalInfo.PluginServerPort}";
+                    if (PluginDetail != null && PluginDetail.RequiredLoaderStruct.SelfLoad)
+                        Process.Start(pluginFile, $"--connect {connectStr}");
+                    else
                     {
-                        string arg = $"--load \"{pluginFile}\" " +
-                            $"--connect {DevicesServer.DefaultDeviceInfoStruct.IPv4}:" +
-                                $"{GlobalInfo.PluginServerPort}";
-                        Log.Information($"Launch Argument: {arg}");
-                        Process.Start(loaderFile, arg);
+                        string loaderFile = $"{Program.Config.Loaders.InstallPath}/{loaderName}/{loaderName}";
+                        if (OperatingSystem.IsWindows())
+                            loaderFile += ".exe";
+                        loaderFile = Path.GetFullPath(loaderFile);
+
+                        Log.Information($"Launch: {pluginFile} through {loaderFile}");
+
+                        if (File.Exists(loaderFile) && File.Exists(pluginFile))
+                        {
+                            string arg = $"--load \"{pluginFile}\" --connect {connectStr}";
+                            Log.Information($"Launch Argument: {arg}");
+                            Process.Start(loaderFile, arg);
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/ViewModels/Pages/Controls/PluginBarViewModel.cs
+++ b/ViewModels/Pages/Controls/PluginBarViewModel.cs
@@ -168,7 +168,7 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("In PluginBarViewModel.Launch()", ex);
+                    Log.Error(ex, "In PluginBarViewModel.Launch()");
                 }
             }).Start();
         }

--- a/ViewModels/Pages/Controls/Settings_GeneralViewModel.cs
+++ b/ViewModels/Pages/Controls/Settings_GeneralViewModel.cs
@@ -1,4 +1,5 @@
-﻿using KitX_Dashboard.Commands;
+﻿using Common.ExternalConsole;
+using KitX_Dashboard.Commands;
 using KitX_Dashboard.Services;
 using Serilog;
 using System;
@@ -10,9 +11,14 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
     internal class Settings_GeneralViewModel : ViewModelBase, INotifyPropertyChanged
     {
 
+        private static Manager _manager = new();
+        private static int _consolesCount = 0;
+
         internal Settings_GeneralViewModel()
         {
             InitCommands();
+
+            InitEvents();
         }
 
         /// <summary>
@@ -21,8 +27,18 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
         private void InitCommands()
         {
             ShowAnnouncementsNowCommand = new(ShowAnnouncementsNow);
+            OpenDebugToolCommand = new(OpenDebugTool);
         }
 
+        /// <summary>
+        /// 初始化事件
+        /// </summary>
+        private void InitEvents()
+        {
+            EventHandlers.DevelopSettingsChanged +=
+                () => PropertyChanged?.Invoke(this, new(nameof(DeveloperSettingEnabled)));
+        }
+        
         /// <summary>
         /// 保存变更
         /// </summary>
@@ -71,6 +87,14 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
         }
 
         /// <summary>
+        /// 是否启用了开发者设置
+        /// </summary>
+        internal static bool DeveloperSettingEnabled
+        {
+            get => Program.Config.App.DeveloperSetting;
+        }
+
+        /// <summary>
         /// 开发者设置项
         /// </summary>
         internal static int DeveloperSettingStatus
@@ -89,6 +113,11 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
         /// </summary>
         internal DelegateCommand? ShowAnnouncementsNowCommand { get; set; }
 
+        /// <summary>
+        /// 打开调试工具命令
+        /// </summary>
+        internal DelegateCommand? OpenDebugToolCommand { get; set; }
+
         private void ShowAnnouncementsNow(object _)
         {
             new Thread(async () =>
@@ -102,6 +131,14 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
                     Log.Error("辣鸡公告系统又双叒叕崩了!", ex);
                 }
             }).Start();
+        }
+
+        private void OpenDebugTool(object _)
+        {
+            ++_consolesCount;
+            var console = _manager.Register($"KitX_{_consolesCount}");
+            console.Start();
+            
         }
 
         public new event PropertyChangedEventHandler? PropertyChanged;

--- a/ViewModels/Pages/Controls/Settings_UpdateViewModel.cs
+++ b/ViewModels/Pages/Controls/Settings_UpdateViewModel.cs
@@ -35,8 +35,6 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
             InitEvents();
 
             InitCommands();
-
-            InitData();
         }
 
         /// <summary>
@@ -60,14 +58,6 @@ namespace KitX_Dashboard.ViewModels.Pages.Controls
         internal void InitCommands()
         {
             CheckUpdateCommand = new(CheckUpdate);
-        }
-
-        /// <summary>
-        /// 初始化数据
-        /// </summary>
-        internal void InitData()
-        {
-
         }
 
         internal int canUpdateCount = 0;

--- a/ViewModels/Pages/RepoPageViewModel.cs
+++ b/ViewModels/Pages/RepoPageViewModel.cs
@@ -127,7 +127,7 @@ namespace KitX_Dashboard.ViewModels.Pages
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("In RepoPageViewModel.ImportPlugin()", ex);
+                        Log.Error(ex, "In RepoPageViewModel.ImportPlugin()");
                     }
                 }).Start();
             }
@@ -163,7 +163,7 @@ namespace KitX_Dashboard.ViewModels.Pages
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("In RefreshPlugins()", ex);
+                        Log.Error(ex, "In RefreshPlugins()");
                     }
                 }
             }

--- a/ViewModels/Pages/RepoPageViewModel.cs
+++ b/ViewModels/Pages/RepoPageViewModel.cs
@@ -142,24 +142,29 @@ namespace KitX_Dashboard.ViewModels.Pages
             //LiteDatabase? pgdb = Program.PluginsDataBase;
 
             PluginBars.Clear();
-            foreach (var item in Program.PluginsList.Plugins)
+            lock (PluginsManager.PluginsListOperationLock)
             {
-                try
+                foreach (var item in Program.PluginsList.Plugins)
                 {
-                    Plugin plugin = new()
+                    try
                     {
-                        InstallPath = item.InstallPath,
-                        PluginDetails = JsonSerializer.Deserialize<PluginStruct>(
-                            File.ReadAllText(Path.GetFullPath($"{item.InstallPath}/PluginStruct.json"))),
-                        RequiredLoaderStruct = JsonSerializer.Deserialize<LoaderStruct>(
-                            File.ReadAllText(Path.GetFullPath($"{item.InstallPath}/LoaderStruct.json"))),
-                        InstalledDevices = new()
-                    };
-                    PluginBars.Add(new(plugin, ref pluginBars));
-                }
-                catch (Exception ex)
-                {
-                    Log.Error("In RefreshPlugins()", ex);
+                        Plugin plugin = new()
+                        {
+                            InstallPath = item.InstallPath,
+                            PluginDetails = JsonSerializer.Deserialize<PluginStruct>(
+                                File.ReadAllText(
+                                    Path.GetFullPath($"{item.InstallPath}/PluginStruct.json"))),
+                            RequiredLoaderStruct = JsonSerializer.Deserialize<LoaderStruct>(
+                                File.ReadAllText(
+                                    Path.GetFullPath($"{item.InstallPath}/LoaderStruct.json"))),
+                            InstalledDevices = new()
+                        };
+                        PluginBars.Add(new(plugin, ref pluginBars));
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error("In RefreshPlugins()", ex);
+                    }
                 }
             }
         }

--- a/ViewModels/PluginDetailWindowViewModel.cs
+++ b/ViewModels/PluginDetailWindowViewModel.cs
@@ -1,26 +1,39 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using FluentAvalonia.Styling;
 using KitX.Web.Rules;
 using KitX_Dashboard.Commands;
+using KitX_Dashboard.Services;
 using Serilog;
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
 
 namespace KitX_Dashboard.ViewModels
 {
-    internal class PluginDetailWindowViewModel : ViewModelBase
+    internal class PluginDetailWindowViewModel : ViewModelBase, INotifyPropertyChanged
     {
         public PluginDetailWindowViewModel()
         {
             InitCommands();
+
+            InitEvents();
         }
 
         internal void InitCommands()
         {
             FinishCommand = new(Finish);
+        }
+
+        internal void InitEvents()
+        {
+            EventHandlers.ThemeConfigChanged +=
+                () => PropertyChanged?.Invoke(this, new(nameof(TintColor)));
         }
 
         internal PluginStruct? PluginDetail { get; set; }
@@ -103,6 +116,19 @@ namespace KitX_Dashboard.ViewModels
 
         internal string? LastUpdateDate => PluginDetail?.LastUpdateDate.ToString("yyyy.MM.dd");
 
+        internal Color TintColor => Program.Config.App.Theme switch
+        {
+            "Light" => Colors.WhiteSmoke,
+            "Dark" => Colors.Black,
+            "Follow" => AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>()?.RequestedTheme switch
+            {
+                "Light" => Colors.WhiteSmoke,
+                "Dark" => Colors.Black,
+                _ => Color.Parse(Program.Config.App.ThemeColor)
+            },
+            _ => Color.Parse(Program.Config.App.ThemeColor),
+        };
+
         private readonly ObservableCollection<string> functions = new();
 
         private readonly ObservableCollection<string> tags = new();
@@ -177,5 +203,7 @@ namespace KitX_Dashboard.ViewModels
         {
             (parent as Window)?.Close();
         }
+
+        public new event PropertyChangedEventHandler? PropertyChanged;
     }
 }

--- a/ViewModels/PluginDetailWindowViewModel.cs
+++ b/ViewModels/PluginDetailWindowViewModel.cs
@@ -4,12 +4,10 @@ using KitX.Web.Rules;
 using KitX_Dashboard.Commands;
 using Serilog;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace KitX_Dashboard.ViewModels
 {

--- a/ViewModels/PluginDetailWindowViewModel.cs
+++ b/ViewModels/PluginDetailWindowViewModel.cs
@@ -33,7 +33,7 @@ namespace KitX_Dashboard.ViewModels
         internal void InitEvents()
         {
             EventHandlers.ThemeConfigChanged +=
-                () => PropertyChanged?.Invoke(this, new(nameof(TintColor)));
+                () => PropertyChanged?.Invoke(this, new(nameof(ViewModels.PluginDetailWindowViewModel.TintColor)));
         }
 
         internal PluginStruct? PluginDetail { get; set; }
@@ -116,7 +116,7 @@ namespace KitX_Dashboard.ViewModels
 
         internal string? LastUpdateDate => PluginDetail?.LastUpdateDate.ToString("yyyy.MM.dd");
 
-        internal Color TintColor => Program.Config.App.Theme switch
+        internal static Color TintColor => Program.Config.App.Theme switch
         {
             "Light" => Colors.WhiteSmoke,
             "Dark" => Colors.Black,
@@ -165,11 +165,11 @@ namespace KitX_Dashboard.ViewModels
                 {
                     StringBuilder sb = new();
                     sb.Append(func.ReturnValueType);
-                    sb.Append(" ");
+                    sb.Append(' ');
                     if (func.DisplayNames.ContainsKey(langKey))
                         sb.Append(func.DisplayNames[langKey]);
                     else sb.Append(func.Name);
-                    sb.Append("(");
+                    sb.Append('(');
                     if (func.Parameters.Count != func.ParametersType.Count)
                         throw new InvalidDataException("Parameters return type count " +
                             "didn't match parameters count.");
@@ -178,14 +178,14 @@ namespace KitX_Dashboard.ViewModels
                     {
                         sb.Append(func.ParametersType[index]);
                         ++index;
-                        sb.Append(" ");
+                        sb.Append(' ');
                         if (param.Value.ContainsKey(langKey))
                             sb.Append(param.Value[langKey]);
                         else sb.Append(param.Key);
                         if (index != func.Parameters.Count)
                             sb.Append(", ");
                     }
-                    sb.Append(")");
+                    sb.Append(')');
                     Functions.Add(sb.ToString());
                 }
                 foreach (var tag in PluginDetail.Value.Tags)

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -18,7 +18,17 @@
         Icon="avares://KitX.Assets/KitX-Icon-32x32.png"
         mc:Ignorable="d">
 
-    <!--  Width="{Binding DB_Width}" Height="{Binding DB_Height}"  -->
+    <Window.Styles>
+        <Style Selector="TextBlock.Normal">
+            <Setter Property="FontFamily" Value="{StaticResource SourceHanSans}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
+        <Style Selector="StackPanel.Item">
+            <Setter Property="Margin" Value="-3,0,0,0"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="Orientation" Value="Horizontal"/>
+        </Style>
+    </Window.Styles>
 
     <Window.Resources>
         <ResourceDictionary>
@@ -50,8 +60,6 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <!--  {DynamicResource Text_MainWindow_NavigationView_Header}  -->
-
     <Grid>
 
         <ui:NavigationView x:Name="MainNavigationView"
@@ -64,14 +72,11 @@
                                        Tag="Page_Home"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Home}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Home"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Home}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -80,14 +85,11 @@
                                        Tag="Page_Lib"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Lib}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Layers"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Lib}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -96,14 +98,11 @@
                                        Tag="Page_Repo"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Repo}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Folder"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Repo}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -112,14 +111,11 @@
                                        Tag="Page_Device"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Devices}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Devices"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Devices}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -131,14 +127,11 @@
                                        Tag="Page_Market"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Market}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Tag"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Market}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -147,14 +140,11 @@
                                        Tag="Page_Account"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Account}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="At"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Account}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -163,14 +153,11 @@
                                        Tag="Page_Settings"
                                        ToolTip.Tip="{DynamicResource Text_MainWindow_NavigationView_Settings}">
                     <ui:NavigationViewItem.Content>
-                        <StackPanel Margin="-3,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Orientation="Horizontal">
+                        <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Settings"/>
                             <TextBlock Margin="15,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
+                                       Classes="Normal"
                                        Text="{DynamicResource Text_MainWindow_NavigationView_Settings}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
@@ -179,9 +166,18 @@
 
             <ui:NavigationView.PaneFooter>
                 <TextBlock Margin="20"
+                           Classes="Normal"
                            IsVisible="{Binding ElementName=MainNavigationView, Path=IsPaneOpen}"
                            Text="{DynamicResource GreetingText}"
-                           TextWrapping="Wrap"/>
+                           TextWrapping="Wrap">
+                    <TextBlock.ContextFlyout>
+                        <ui:MenuFlyout>
+                            <ui:MenuFlyoutItem Command="{Binding RefreshGreetingCommand}"
+                                               CommandParameter="{DynamicResource MainWindow}"
+                                               Text="{DynamicResource Text_Public_Refresh}"/>
+                        </ui:MenuFlyout>
+                    </TextBlock.ContextFlyout>
+                </TextBlock>
             </ui:NavigationView.PaneFooter>
 
             <ui:Frame x:Name="MainFrame" IsNavigationStackEnabled="False"/>

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -22,6 +22,8 @@
         <Style Selector="TextBlock.Normal">
             <Setter Property="FontFamily" Value="{StaticResource SourceHanSans}"/>
             <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Margin" Value="15,0,0,0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
         <Style Selector="StackPanel.Item">
             <Setter Property="Margin" Value="-3,0,0,0"/>
@@ -74,10 +76,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Home"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Home}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Home}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>
@@ -87,10 +86,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Layers"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Lib}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Lib}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>
@@ -100,10 +96,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Folder"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Repo}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Repo}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>
@@ -113,10 +106,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Devices"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Devices}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Devices}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>
@@ -129,10 +119,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Tag"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Market}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Market}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>
@@ -142,10 +129,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="At"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Account}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Account}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>
@@ -155,10 +139,7 @@
                     <ui:NavigationViewItem.Content>
                         <StackPanel Classes="Item">
                             <icon:MaterialIcon VerticalAlignment="Center" Kind="Settings"/>
-                            <TextBlock Margin="15,0,0,0"
-                                       VerticalAlignment="Center"
-                                       Classes="Normal"
-                                       Text="{DynamicResource Text_MainWindow_NavigationView_Settings}"/>
+                            <TextBlock Classes="Normal" Text="{DynamicResource Text_MainWindow_NavigationView_Settings}"/>
                         </StackPanel>
                     </ui:NavigationViewItem.Content>
                 </ui:NavigationViewItem>

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -178,7 +178,7 @@ namespace KitX_Dashboard.Views
         /// <summary>
         /// 更新招呼语
         /// </summary>
-        private void UpdateGreetingText()
+        internal void UpdateGreetingText()
         {
             try
             {

--- a/Views/Pages/Controls/Settings_General.axaml
+++ b/Views/Pages/Controls/Settings_General.axaml
@@ -121,6 +121,14 @@
                         <ComboBoxItem Content="{DynamicResource Text_Public_Disable}"/>
                     </ComboBox>
 
+                    <Button Margin="0,0,10,0"
+                            Command="{Binding OpenDebugToolCommand}"
+                            Content="{DynamicResource Text_Settings_General_OpenDebugTool}"
+                            DockPanel.Dock="Right"
+                            FontFamily="{StaticResource SourceHanSans}"
+                            FontWeight="Bold"
+                            IsVisible="{Binding DeveloperSettingEnabled}"/>
+
                     <Border/>
                 </DockPanel>
             </ui:InfoBar>

--- a/Views/Pages/Controls/Settings_Performence.axaml
+++ b/Views/Pages/Controls/Settings_Performence.axaml
@@ -23,7 +23,7 @@
             <Setter Property="DockPanel.Dock" Value="Right"/>
             <Setter Property="IsEnabled" Value="True"/>
         </Style>
-        <Style Selector="TextBlock">
+        <Style Selector="TextBlock.Normal">
             <Setter Property="FontFamily" Value="{StaticResource SourceHanSans}"/>
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
@@ -48,7 +48,7 @@
                 <DockPanel Margin="0,10,10,10">
                     <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="Lan"/>
-                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Web_PluginsServerPort}"/>
+                        <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_Web_PluginsServerPort}"/>
                     </StackPanel>
 
                     <ui:NumberBox Classes="Disabled"
@@ -66,7 +66,7 @@
                 <DockPanel Margin="0,10,10,10">
                     <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="LanConnect"/>
-                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Web_DevicesServerPort}"/>
+                        <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_Web_DevicesServerPort}"/>
                     </StackPanel>
 
                     <ui:NumberBox Classes="Disabled"
@@ -84,7 +84,7 @@
                 <DockPanel Margin="0,10,10,10">
                     <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="IpNetwork"/>
-                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Web_MyIP_Filter}"/>
+                        <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_Web_MyIP_Filter}"/>
                     </StackPanel>
 
                     <TextBox DockPanel.Dock="Right" Text="{Binding LocalIPFilter}"/>
@@ -100,9 +100,14 @@
                 <DockPanel Margin="0,10,10,10">
                     <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="Clock"/>
-                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Greeting_Interval}"/>
+                        <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_Greeting_Interval}"/>
                     </StackPanel>
 
+                    <TextBlock Margin="10,0,0,0"
+                               VerticalAlignment="Center"
+                               Classes="Normal"
+                               DockPanel.Dock="Right"
+                               Text="{DynamicResource Text_Public_Minute}"/>
                     <ui:NumberBox Classes="Enabled"
                                   Maximum="60"
                                   Minimum="1"
@@ -117,7 +122,7 @@
                 <Expander.Header>
                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                         <icon:MaterialIcon Margin="5,0" Kind="FileChart"/>
-                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Log}"/>
+                        <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_Log}"/>
                     </StackPanel>
                 </Expander.Header>
 
@@ -135,9 +140,7 @@
                         <DockPanel Margin="0,10,10,10">
                             <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="DataUsage"/>
-                                <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                           FontWeight="Bold"
-                                           Text="{DynamicResource Text_Settings_Performence_LogFileSizeUsage}"/>
+                                <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_LogFileSizeUsage}"/>
                             </StackPanel>
                             <Button Command="{Binding EmptyLogsCommand}"
                                     Content="{DynamicResource Text_Public_Empty}"
@@ -146,6 +149,7 @@
                                     FontWeight="Bold"/>
                             <TextBlock Margin="10,0"
                                        VerticalAlignment="Center"
+                                       Classes="Normal"
                                        DockPanel.Dock="Right"
                                        Text="MB"/>
                             <ui:NumberBox Classes="Disabled"
@@ -163,14 +167,13 @@
                         <DockPanel Margin="0,10,10,10">
                             <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="Sd"/>
-                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileSize}"/>
+                                <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_LogFileSize}"/>
                             </StackPanel>
 
                             <TextBlock Margin="10,0,0,0"
                                        VerticalAlignment="Center"
+                                       Classes="Normal"
                                        DockPanel.Dock="Right"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
                                        Text="MB"/>
                             <ui:NumberBox Classes="Enabled"
                                           Minimum="1"
@@ -188,7 +191,7 @@
                         <DockPanel Margin="0,10,10,10">
                             <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="FileMultiple"/>
-                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileMaxCount}"/>
+                                <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_LogFileMaxCount}"/>
                             </StackPanel>
 
                             <ui:NumberBox Classes="Enabled"
@@ -206,11 +209,12 @@
                         <DockPanel Margin="0,10,10,10">
                             <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="FileClock"/>
-                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileFlushInterval}"/>
+                                <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_LogFileFlushInterval}"/>
                             </StackPanel>
 
                             <TextBlock Margin="10,0,0,0"
                                        VerticalAlignment="Center"
+                                       Classes="Normal"
                                        DockPanel.Dock="Right"
                                        Text="{DynamicResource Text_Public_Second}"/>
                             <ui:NumberBox Classes="Enabled"
@@ -228,7 +232,7 @@
                         <DockPanel Margin="0,10,10,10">
                             <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="FileDocument"/>
-                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileLevel}"/>
+                                <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_LogFileLevel}"/>
                             </StackPanel>
 
                             <ComboBox VerticalContentAlignment="Center"
@@ -240,7 +244,7 @@
                                       SelectedItem="{Binding CurrentLogLevel}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
-                                        <TextBlock Text="{Binding LogLevelDisplayName}"/>
+                                        <TextBlock Classes="Normal" Text="{Binding LogLevelDisplayName}"/>
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
@@ -260,9 +264,7 @@
                 <DockPanel Margin="0,10,10,10">
                     <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="DirectionsFork"/>
-                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                   FontWeight="Bold"
-                                   Text="{DynamicResource Text_Settings_Performence_CheckerPerThreadFilesCountLimit}"/>
+                        <TextBlock Classes="Normal" Text="{DynamicResource Text_Settings_Performence_CheckerPerThreadFilesCountLimit}"/>
                     </StackPanel>
 
                     <ui:NumberBox Classes="Enabled"

--- a/Views/Pages/Controls/Settings_Performence.axaml
+++ b/Views/Pages/Controls/Settings_Performence.axaml
@@ -129,7 +129,47 @@
 
                 <StackPanel>
 
-                    <ui:InfoBar Margin="0,5,0,10"
+                    <ui:InfoBar Margin="0,5"
+                                IsClosable="False"
+                                IsIconVisible="False"
+                                IsOpen="True">
+                        <ui:InfoBar.ContextFlyout>
+                            <ui:MenuFlyout>
+                                <ui:MenuFlyoutItem Command="{Binding RefreshLogsUsageCommand}" Text="{DynamicResource Text_Public_Refresh}"/>
+                            </ui:MenuFlyout>
+                        </ui:InfoBar.ContextFlyout>
+                        <DockPanel Margin="0,10,10,10">
+                            <StackPanel VerticalAlignment="Center"
+                                        DockPanel.Dock="Left"
+                                        Orientation="Horizontal">
+                                <icon:MaterialIcon Margin="5,0" Kind="DataUsage"/>
+                                <TextBlock FontFamily="{StaticResource SourceHanSans}"
+                                           FontWeight="Bold"
+                                           Text="{DynamicResource Text_Settings_Performence_LogFileSizeUsage}"/>
+                            </StackPanel>
+                            <Button Command="{Binding EmptyLogsCommand}"
+                                    Content="{DynamicResource Text_Public_Empty}"
+                                    DockPanel.Dock="Right"
+                                    FontFamily="{StaticResource SourceHanSans}"
+                                    FontWeight="Bold"/>
+                            <TextBlock Margin="10,0"
+                                       VerticalAlignment="Center"
+                                       DockPanel.Dock="Right"
+                                       FontFamily="{StaticResource SourceHanSans}"
+                                       FontWeight="Bold"
+                                       Text="MB"/>
+                            <ui:NumberBox DockPanel.Dock="Right"
+                                          FontFamily="{StaticResource SourceHanSans}"
+                                          FontWeight="Bold"
+                                          IsEnabled="False"
+                                          Minimum="1"
+                                          SpinButtonPlacementMode="Compact"
+                                          Value="{Binding LogFileSizeUsage}"/>
+                            <Border/>
+                        </DockPanel>
+                    </ui:InfoBar>
+
+                    <ui:InfoBar Margin="0,5"
                                 IsClosable="False"
                                 IsIconVisible="False"
                                 IsOpen="True">

--- a/Views/Pages/Controls/Settings_Performence.axaml
+++ b/Views/Pages/Controls/Settings_Performence.axaml
@@ -10,6 +10,30 @@
              d:DesignWidth="800"
              mc:Ignorable="d">
 
+    <UserControl.Styles>
+        <Style Selector="ui|NumberBox.Disabled">
+            <Setter Property="FontFamily" Value="{StaticResource SourceHanSans}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="DockPanel.Dock" Value="Right"/>
+            <Setter Property="IsEnabled" Value="False"/>
+        </Style>
+        <Style Selector="ui|NumberBox.Enabled">
+            <Setter Property="FontFamily" Value="{StaticResource SourceHanSans}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="DockPanel.Dock" Value="Right"/>
+            <Setter Property="IsEnabled" Value="True"/>
+        </Style>
+        <Style Selector="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource SourceHanSans}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
+        <Style Selector="StackPanel.TitleBar">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Orientation" Value="Horizontal"/>
+            <Setter Property="DockPanel.Dock" Value="Left"/>
+        </Style>
+    </UserControl.Styles>
+
     <UserControl.Resources>
         <converters:Selection2VisibleConverter x:Key="Converter_S2V"/>
     </UserControl.Resources>
@@ -22,19 +46,12 @@
                         IsIconVisible="False"
                         IsOpen="True">
                 <DockPanel Margin="0,10,10,10">
-                    <StackPanel VerticalAlignment="Center"
-                                DockPanel.Dock="Left"
-                                Orientation="Horizontal">
+                    <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="Lan"/>
-                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                   FontWeight="Bold"
-                                   Text="{DynamicResource Text_Settings_Performence_Web_PluginsServerPort}"/>
+                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Web_PluginsServerPort}"/>
                     </StackPanel>
 
-                    <ui:NumberBox DockPanel.Dock="Right"
-                                  FontFamily="{StaticResource SourceHanSans}"
-                                  FontWeight="Bold"
-                                  IsEnabled="False"
+                    <ui:NumberBox Classes="Disabled"
                                   SpinButtonPlacementMode="Compact"
                                   Value="{Binding PluginsServerPort}"/>
 
@@ -47,19 +64,12 @@
                         IsIconVisible="False"
                         IsOpen="True">
                 <DockPanel Margin="0,10,10,10">
-                    <StackPanel VerticalAlignment="Center"
-                                DockPanel.Dock="Left"
-                                Orientation="Horizontal">
+                    <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="LanConnect"/>
-                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                   FontWeight="Bold"
-                                   Text="{DynamicResource Text_Settings_Performence_Web_DevicesServerPort}"/>
+                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Web_DevicesServerPort}"/>
                     </StackPanel>
 
-                    <ui:NumberBox DockPanel.Dock="Right"
-                                  FontFamily="{StaticResource SourceHanSans}"
-                                  FontWeight="Bold"
-                                  IsEnabled="False"
+                    <ui:NumberBox Classes="Disabled"
                                   SpinButtonPlacementMode="Compact"
                                   Value="{Binding DevicesServerPort}"/>
 
@@ -72,19 +82,12 @@
                         IsIconVisible="False"
                         IsOpen="True">
                 <DockPanel Margin="0,10,10,10">
-                    <StackPanel VerticalAlignment="Center"
-                                DockPanel.Dock="Left"
-                                Orientation="Horizontal">
+                    <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="IpNetwork"/>
-                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                   FontWeight="Bold"
-                                   Text="{DynamicResource Text_Settings_Performence_Web_MyIP_Filter}"/>
+                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Web_MyIP_Filter}"/>
                     </StackPanel>
 
-                    <TextBox DockPanel.Dock="Right"
-                             FontFamily="{StaticResource SourceHanSans}"
-                             FontWeight="Bold"
-                             Text="{Binding LocalIPFilter}"/>
+                    <TextBox DockPanel.Dock="Right" Text="{Binding LocalIPFilter}"/>
 
                     <Border/>
                 </DockPanel>
@@ -95,19 +98,12 @@
                         IsIconVisible="False"
                         IsOpen="True">
                 <DockPanel Margin="0,10,10,10">
-                    <StackPanel VerticalAlignment="Center"
-                                DockPanel.Dock="Left"
-                                Orientation="Horizontal">
+                    <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="Clock"/>
-                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                   FontWeight="Bold"
-                                   Text="{DynamicResource Text_Settings_Performence_Greeting_Interval}"/>
+                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Greeting_Interval}"/>
                     </StackPanel>
 
-                    <ui:NumberBox DockPanel.Dock="Right"
-                                  FontFamily="{StaticResource SourceHanSans}"
-                                  FontWeight="Bold"
-                                  IsEnabled="True"
+                    <ui:NumberBox Classes="Enabled"
                                   Maximum="60"
                                   Minimum="1"
                                   SpinButtonPlacementMode="Compact"
@@ -121,9 +117,7 @@
                 <Expander.Header>
                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                         <icon:MaterialIcon Margin="5,0" Kind="FileChart"/>
-                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                   FontWeight="Bold"
-                                   Text="{DynamicResource Text_Settings_Performence_Log}"/>
+                        <TextBlock Text="{DynamicResource Text_Settings_Performence_Log}"/>
                     </StackPanel>
                 </Expander.Header>
 
@@ -139,9 +133,7 @@
                             </ui:MenuFlyout>
                         </ui:InfoBar.ContextFlyout>
                         <DockPanel Margin="0,10,10,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        DockPanel.Dock="Left"
-                                        Orientation="Horizontal">
+                            <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="DataUsage"/>
                                 <TextBlock FontFamily="{StaticResource SourceHanSans}"
                                            FontWeight="Bold"
@@ -155,13 +147,8 @@
                             <TextBlock Margin="10,0"
                                        VerticalAlignment="Center"
                                        DockPanel.Dock="Right"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
                                        Text="MB"/>
-                            <ui:NumberBox DockPanel.Dock="Right"
-                                          FontFamily="{StaticResource SourceHanSans}"
-                                          FontWeight="Bold"
-                                          IsEnabled="False"
+                            <ui:NumberBox Classes="Disabled"
                                           Minimum="1"
                                           SpinButtonPlacementMode="Compact"
                                           Value="{Binding LogFileSizeUsage}"/>
@@ -174,13 +161,9 @@
                                 IsIconVisible="False"
                                 IsOpen="True">
                         <DockPanel Margin="0,10,10,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        DockPanel.Dock="Left"
-                                        Orientation="Horizontal">
+                            <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="Sd"/>
-                                <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                           FontWeight="Bold"
-                                           Text="{DynamicResource Text_Settings_Performence_LogFileSize}"/>
+                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileSize}"/>
                             </StackPanel>
 
                             <TextBlock Margin="10,0,0,0"
@@ -189,10 +172,7 @@
                                        FontFamily="{StaticResource SourceHanSans}"
                                        FontWeight="Bold"
                                        Text="MB"/>
-                            <ui:NumberBox DockPanel.Dock="Right"
-                                          FontFamily="{StaticResource SourceHanSans}"
-                                          FontWeight="Bold"
-                                          IsEnabled="True"
+                            <ui:NumberBox Classes="Enabled"
                                           Minimum="1"
                                           SpinButtonPlacementMode="Compact"
                                           Value="{Binding LogFileSizeLimit}"/>
@@ -206,19 +186,12 @@
                                 IsIconVisible="False"
                                 IsOpen="True">
                         <DockPanel Margin="0,10,10,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        DockPanel.Dock="Left"
-                                        Orientation="Horizontal">
+                            <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="FileMultiple"/>
-                                <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                           FontWeight="Bold"
-                                           Text="{DynamicResource Text_Settings_Performence_LogFileMaxCount}"/>
+                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileMaxCount}"/>
                             </StackPanel>
 
-                            <ui:NumberBox DockPanel.Dock="Right"
-                                          FontFamily="{StaticResource SourceHanSans}"
-                                          FontWeight="Bold"
-                                          IsEnabled="True"
+                            <ui:NumberBox Classes="Enabled"
                                           SpinButtonPlacementMode="Compact"
                                           Value="{Binding LogFileMaxCount}"/>
 
@@ -231,25 +204,16 @@
                                 IsIconVisible="False"
                                 IsOpen="True">
                         <DockPanel Margin="0,10,10,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        DockPanel.Dock="Left"
-                                        Orientation="Horizontal">
+                            <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="FileClock"/>
-                                <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                           FontWeight="Bold"
-                                           Text="{DynamicResource Text_Settings_Performence_LogFileFlushInterval}"/>
+                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileFlushInterval}"/>
                             </StackPanel>
 
                             <TextBlock Margin="10,0,0,0"
                                        VerticalAlignment="Center"
                                        DockPanel.Dock="Right"
-                                       FontFamily="{StaticResource SourceHanSans}"
-                                       FontWeight="Bold"
                                        Text="{DynamicResource Text_Public_Second}"/>
-                            <ui:NumberBox DockPanel.Dock="Right"
-                                          FontFamily="{StaticResource SourceHanSans}"
-                                          FontWeight="Bold"
-                                          IsEnabled="True"
+                            <ui:NumberBox Classes="Enabled"
                                           SpinButtonPlacementMode="Compact"
                                           Value="{Binding LogFileFlushInterval}"/>
 
@@ -262,13 +226,9 @@
                                 IsIconVisible="False"
                                 IsOpen="True">
                         <DockPanel Margin="0,10,10,10">
-                            <StackPanel VerticalAlignment="Center"
-                                        DockPanel.Dock="Left"
-                                        Orientation="Horizontal">
+                            <StackPanel Classes="TitleBar">
                                 <icon:MaterialIcon Margin="5,0" Kind="FileDocument"/>
-                                <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                           FontWeight="Bold"
-                                           Text="{DynamicResource Text_Settings_Performence_LogFileLevel}"/>
+                                <TextBlock Text="{DynamicResource Text_Settings_Performence_LogFileLevel}"/>
                             </StackPanel>
 
                             <ComboBox VerticalContentAlignment="Center"
@@ -280,9 +240,7 @@
                                       SelectedItem="{Binding CurrentLogLevel}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
-                                        <TextBlock FontFamily="{StaticResource SourceHanSans}"
-                                                   FontWeight="Bold"
-                                                   Text="{Binding LogLevelDisplayName}"/>
+                                        <TextBlock Text="{Binding LogLevelDisplayName}"/>
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
@@ -300,19 +258,14 @@
                         IsIconVisible="False"
                         IsOpen="True">
                 <DockPanel Margin="0,10,10,10">
-                    <StackPanel VerticalAlignment="Center"
-                                DockPanel.Dock="Left"
-                                Orientation="Horizontal">
+                    <StackPanel Classes="TitleBar">
                         <icon:MaterialIcon Margin="5,0" Kind="DirectionsFork"/>
                         <TextBlock FontFamily="{StaticResource SourceHanSans}"
                                    FontWeight="Bold"
                                    Text="{DynamicResource Text_Settings_Performence_CheckerPerThreadFilesCountLimit}"/>
                     </StackPanel>
 
-                    <ui:NumberBox DockPanel.Dock="Right"
-                                  FontFamily="{StaticResource SourceHanSans}"
-                                  FontWeight="Bold"
-                                  IsEnabled="True"
+                    <ui:NumberBox Classes="Enabled"
                                   Maximum="100"
                                   Minimum="1"
                                   SpinButtonPlacementMode="Compact"

--- a/Views/Pages/RepoPage.axaml.cs
+++ b/Views/Pages/RepoPage.axaml.cs
@@ -47,7 +47,7 @@ namespace KitX_Dashboard.Views.Pages
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("In RepoPage.Drop()", ex);
+                        Log.Error(ex, "In RepoPage.Drop()");
                     }
                 }).Start();
             }

--- a/Views/PluginDetailWindow.axaml
+++ b/Views/PluginDetailWindow.axaml
@@ -12,6 +12,7 @@
         d:DesignWidth="800"
         Background="Transparent"
         ExtendClientAreaToDecorationsHint="True"
+        Icon="avares://KitX.Assets/KitX-Icon-32x32.png"
         TransparencyLevelHint="AcrylicBlur"
         mc:Ignorable="d">
 
@@ -29,11 +30,11 @@
             </ExperimentalAcrylicBorder.Material>
         </ExperimentalAcrylicBorder>
 
-        <ScrollViewer Margin="0,40,0,0">
+        <ScrollViewer Margin="20,20,20,60">
 
             <Panel>
 
-                <StackPanel Margin="25,0,25,25">
+                <StackPanel Margin="5,5,15,35">
 
                     <DockPanel>
 
@@ -185,13 +186,11 @@
                             <ListBox Margin="0,10,0,0" Items="{Binding Functions}"/>
                         </TabItem>
                         <TabItem FontSize="16" Header="{DynamicResource Text_Plugin_Tags}">
-                            <ListBox Margin="0,10,0,0">
-                                <ListBoxItem Content="Tag1: aaa"/>
-                                <ListBoxItem Content="Tag2: bbb"/>
-                                <ListBoxItem Content="Tag3: ccc"/>
-                            </ListBox>
+                            <ListBox Margin="0,10,0,0" Items="{Binding Tags}"/>
                         </TabItem>
                     </TabControl>
+
+                    <Border Height="100"/>
 
                 </StackPanel>
 

--- a/Views/PluginDetailWindow.axaml
+++ b/Views/PluginDetailWindow.axaml
@@ -25,7 +25,7 @@
             <ExperimentalAcrylicBorder.Material>
                 <ExperimentalAcrylicMaterial BackgroundSource="Digger"
                                              MaterialOpacity="0"
-                                             TintColor="Black"
+                                             TintColor="{Binding TintColor}"
                                              TintOpacity="1"/>
             </ExperimentalAcrylicBorder.Material>
         </ExperimentalAcrylicBorder>
@@ -80,7 +80,7 @@
                             <ExperimentalAcrylicBorder.Material>
                                 <ExperimentalAcrylicMaterial BackgroundSource="Digger"
                                                              MaterialOpacity="0.1"
-                                                             TintColor="Black"
+                                                             TintColor="{Binding TintColor}"
                                                              TintOpacity="1"/>
                             </ExperimentalAcrylicBorder.Material>
                         </ExperimentalAcrylicBorder>

--- a/Views/PluginDetailWindow.axaml.cs
+++ b/Views/PluginDetailWindow.axaml.cs
@@ -1,7 +1,7 @@
 ﻿using Avalonia.Controls;
+using Common.BasicHelper.UI.Screen;
 using KitX.Web.Rules;
 using KitX_Dashboard.ViewModels;
-using Common.BasicHelper.UI.Screen;
 
 namespace KitX_Dashboard.Views
 {


### PR DESCRIPTION
## What does this MR do?

### 六项修复及优化
1. [🔧 💾 Fix, Feat: 修复插件管理逻辑多重导入与删不掉的问题, 插件详情页UI调整](https://github.com/Crequency/KitX-Dashboard/commit/96df40624cb7ee5c24f4aec29aada32b186165f8)
2. [🔧 Fix: 增加对插件列表的操作锁](https://github.com/Crequency/KitX-Dashboard/commit/902b8eb61378a60699a746c630ad2587bb06ccf0)
3. [💾 Feat: 使用优化的导入插件算法, 避免二次解包](https://github.com/Crequency/KitX-Dashboard/commit/c1c1777e081ad6de1fd482b68df76a880d30f5f9)
4. [💾 🔧 Feat, Fix: 插件详情页增加对应用主题的支持, 同时响应主题变更](https://github.com/Crequency/KitX-Dashboard/commit/40a2409c55f596ce532d7cac95f9aec218133470)
5. [💾 📝 Feat, Chore: 退出时强制刷新日志缓存, 更新 NuGet 引用](https://github.com/Crequency/KitX-Dashboard/commit/31692180231c35bac3ec7c0b6b0dd062b8d15898)
6. [💾 Feat: 对桌面通知组件的预编译优化](https://github.com/Crequency/KitX-Dashboard/commit/158691cb68d3a703f58331cbff73ec276182d5f3)

### 四项新增
1. [💾 🔧 Feat, Fix: 插件详情页增加对应用主题的支持, 同时响应主题变更](https://github.com/Crequency/KitX-Dashboard/commit/40a2409c55f596ce532d7cac95f9aec218133470)
2. [💾 📝 Feat, Chore: 招呼语右键刷新, Windows 平台引入系统消息通知并完成多发布目标适配](https://github.com/Crequency/KitX-Dashboard/commit/b62408c7d966afe7a328392dfa36a0282e17ad25)
3. [💾 📝 Feat, Chore: 使用桌面通知组件发送通知, 引用桌面通知组件](https://github.com/Crequency/KitX-Dashboard/commit/aaa99553effdb842e3f570995320e979182bf160)
4. [💾 Feat: 打开调试工具相关 UI](https://github.com/Crequency/KitX-Dashboard/commit/241a3d1ed93ca4b11658a3a5c521634c47f908f5)

## Related issues

1. Close Crequency/KitX#195.
2. Refer Crequency/KitX#223.
