### PR TITLE
[Pull Request] 缓存管理器的更新; 实装重写的调试工具; 其它更新

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-## What does this MR do?
+## What does this PR do?
 
-<!-- Briefly describe what this MR is about -->
+<!-- Briefly describe what this PR is about -->
 
 ## Related issues
 

--- a/Data/AppConfig.cs
+++ b/Data/AppConfig.cs
@@ -337,6 +337,9 @@ public class AppConfig
 
         [JsonInclude]
         public string UpdateSource { get; set; } = "latest-components.json";
+
+        [JsonInclude]
+        public int DebugServicesServerPort { get; set; } = 7777;
     }
 
     /// <summary>

--- a/Data/AppConfig.cs
+++ b/Data/AppConfig.cs
@@ -1,8 +1,8 @@
 ﻿using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
 using Serilog.Events;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using FluentAvalonia.UI.Controls;
 
 namespace KitX_Dashboard.Data;
 

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -158,7 +158,8 @@
         <ProjectReference Include="..\Reference\Common.Activity\src\Common.Activity.csproj" />
         <ProjectReference Include="..\Reference\Common.Algorithm\Common.Algorithm.Interop\Common.Algorithm.Interop.csproj" />
         <ProjectReference Include="..\Reference\Common.BasicHelper\Common.BasicHelper\Common.BasicHelper.csproj" />
-        <ProjectReference Include="..\Reference\Common.ExternalConsole\Common.ExternalConsole.Console\Common.ExternalConsole.Console.csproj" Condition="$(Is2Publish) == 'False'" />
+        <ProjectReference Include="..\Reference\Common.ExternalConsole\Common.ExternalConsole\Common.ExternalConsole.csproj"/>
+        <ProjectReference Include="..\Reference\Common.ExternalConsole\Common.ExternalConsole.ExternalConsole\Common.ExternalConsole.ExternalConsole.csproj"  Condition="$(Is2Publish) == 'False'" />
         <ProjectReference Include="..\Reference\Common.Update\Common.Update.Checker\Common.Update.Checker.csproj" />
     </ItemGroup>
 </Project>

--- a/KitX Dashboard.csproj
+++ b/KitX Dashboard.csproj
@@ -100,6 +100,9 @@
         <None Update="Assets\KitX.Base64.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="clean-debug.sh">
+            <CopyToOutputDirectory Condition="'$(Configuration)' == 'Debug'">PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Assets\KitX-Icon-256x.ico">

--- a/Managers/WebManager.cs
+++ b/Managers/WebManager.cs
@@ -1,7 +1,6 @@
 ﻿using KitX_Dashboard.Servers;
 using Serilog;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 

--- a/Servers/DevicesServer.cs
+++ b/Servers/DevicesServer.cs
@@ -490,7 +490,8 @@ internal class DevicesServer : IDisposable
 
         listener.Start();
 
-        int port = ((IPEndPoint)listener.LocalEndpoint).Port; // 取服务端口号
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port; // 取服务端口号
+
         GlobalInfo.DeviceServerPort = port; // 全局端口号标明
         GlobalInfo.ServerBuildTime = DateTime.UtcNow;
         GlobalInfo.IsMainMachine = true;

--- a/Services/DebugService.cs
+++ b/Services/DebugService.cs
@@ -1,6 +1,5 @@
 ﻿using KitX_Dashboard.Servers;
 using Serilog;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Services/DebugService.cs
+++ b/Services/DebugService.cs
@@ -1,6 +1,8 @@
 ﻿using KitX_Dashboard.Servers;
 using Serilog;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -168,17 +170,53 @@ internal class DebugCommands
 
     public static string? Cache(Dictionary<string, string> args)
     {
-
-        if (args.ContainsKey("--file"))
+        try
         {
-            var path = args["--file"];
-            if (path.StartsWith('"') && path.EndsWith('"'))
-                path = path[1..^1];
-            Log.Information(path);
-            var id = Program.CacheManager?.LoadFileToCache(path);
-            return $"File loaded, ID (MD5): {id?.Result ?? "null"}";
+            if (args.ContainsKey("help"))
+            {
+                return "" +
+                    "Load file to CacheManager.\n" +
+                    "\t--file | with path of file, if contain space, quote it.";
+            }
+            if (args.ContainsKey("--file"))
+            {
+                var path = args["--file"];
+
+                if (path.StartsWith('"') && path.EndsWith('"'))
+                    path = path[1..^1];
+
+                Log.Information($"Debug Tool: Request CacheManager to load {path}");
+
+                path = Path.GetFullPath(path);
+
+                if (!File.Exists(path)) return "File not found.";
+
+                if (args.ContainsKey("--way"))
+                {
+                    switch (args["--way"])
+                    {
+                        case "complete": break;
+                        case "fragment":
+                            //ToDo: Load file in fragments.
+                            return "";
+                    }
+                }
+
+                var info = new FileInfo(path);
+
+                if (info.Length > 2.0 * 1024 * 1024 * 1024 - 500)
+                    return "File larger than 2 GB, unsupported by this way";
+
+                var id = Program.CacheManager?.LoadFileToCache(path);
+
+                return $"File loaded, ID (MD5): {id?.Result ?? "null"}";
+            }
+            else return "Missing arguments.";
         }
-        else return "Missing arguments.";
+        catch (Exception ex)
+        {
+            return $"Error when executing, ex: {ex.Message}";
+        }
     }
 
     public static string? Dispose(Dictionary<string, string> args)

--- a/ViewModels/Pages/Controls/Settings_GeneralViewModel.cs
+++ b/ViewModels/Pages/Controls/Settings_GeneralViewModel.cs
@@ -209,17 +209,28 @@ internal class Settings_GeneralViewModel : ViewModelBase, INotifyPropertyChanged
 
                 async void Writer(StreamWriter writer)
                 {
-                    while (keepWorking)
+                    try
                     {
-                        if (messages2Send.Count > 0)
+                        while (keepWorking)
                         {
-                            await writer.WriteLineAsync(
-                                messages2Send.Dequeue()
-                                .Replace("\r\n", "\n")
-                                .Replace("\n", "|^new_line|")
-                            );
-                            await writer.FlushAsync();
+                            if (messages2Send.Count > 0)
+                            {
+                                await writer.WriteLineAsync(
+                                    messages2Send.Dequeue()
+                                    .Replace("\r\n", "\n")
+                                    .Replace("\n", "|^new_line|")
+                                );
+                                await writer.FlushAsync();
+                            }
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        await writer.DisposeAsync();
+                        console.Dispose();
+
+                        var location = $"{nameof(Settings_UpdateViewModel)}.{nameof(OpenDebugTool)}";
+                        Log.Warning(ex, $"In {location}: {ex.Message}");
                     }
                 }
 

--- a/ViewModels/Pages/Controls/Settings_UpdateViewModel.cs
+++ b/ViewModels/Pages/Controls/Settings_UpdateViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using Common.ExternalConsole.Client;
 using Common.Update.Checker;
 using KitX.Web.Rules;
 using KitX_Dashboard.Commands;

--- a/clean-debug.sh
+++ b/clean-debug.sh
@@ -1,0 +1,15 @@
+﻿#!/bin/bash
+
+rm -rf cs/
+rm -rf de/
+rm -rf es/
+rm -rf fr/
+rm -rf it/
+rm -rf ja/
+rm -rf ko/
+rm -rf pl/
+rm -rf pt-BR/
+rm -rf ru/
+rm -rf tr/
+rm -rf zh-Hans/
+rm -rf zh-Hant/


### PR DESCRIPTION
## What does this MR do?

1. 缓存管理器
  - 使用 MD5 作为标识符的缓存管理器, 目前用于文件缓存
  - 目前支持 2GB 以内的文件单次完全载入内存
  - 支持释放, 且性能出色
2. 调试工具
  - 在 [Common.ExternalConsole](https://github.com/Crequency/Common.ExternalConsole) 项目中, 使用 TCP 重写了相关逻辑, 现在网络连接更稳定了
  - 添加了针对缓存管理器的测试命令
3. 其他更新
  - 构建脚本: 添加了一键清除语言资产文件的脚本, Debug 模式复制到输出目录, 这些资产文件是不需要的

<!-- Briefly describe what this MR is about -->

## Related issues

nope.

<!-- Link related issues below. -->
